### PR TITLE
Update sinatra.rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # mock_sinatra
 
 A simple mocking of some 'key' points to Sinatra functioning.
+
+Right out of sinatra/base.rb
+
+```ruby
+routes.each do |pattern, keys, conditions, block|
+```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# mock_sinatra
+
+A simple mocking of some 'key' points to Sinatra functioning.

--- a/runner.rb
+++ b/runner.rb
@@ -4,14 +4,14 @@ get "/hi" do
   puts "I am the hi method"
 end
 
-#Proc instance gets assigned to a variable, locally stored block code can be assessed later
-
-run("/hi")
+# Proc instance gets assigned to a variable, locally stored block code can be assessed later
+# run("/hi") # Error. before filter is nil
 
 before "/hi" do
   puts "Running before filter"
   puts "------------------"
 end
+# same here assigned to a block variable
 
 run("/hi")
 run("/random")  #Error

--- a/runner.rb
+++ b/runner.rb
@@ -1,14 +1,17 @@
 require "./sinatra.rb"
 
-# Procs instances get assigned to a variable, locally stored block code can be assessed later.
+# Procs instances get assigned to a hash value, locally stored block code can be assessed later.
 get "/hi" do
-  puts "I am in the hi block"
+  puts "I am the hi proc in a hash."
+  puts "My key is me and my data is a proc."
 end
 
 run("/hi")
 
 before "/hi" do
-  puts "Running before block"
+  puts "I am the before filter proc in a hash."
+  puts "My key is hi and my data is a proc"
+  puts "But I'm a different hash than get is."
   puts "------------------"
 end
 

--- a/runner.rb
+++ b/runner.rb
@@ -24,7 +24,7 @@ run("/random")  #Error
 get '/hi', &block = lambda { puts "I am in the lambda" }
 run("/hi")
 
-before "/hi", &block = lambda { puts "Running before block"; puts "------------------" }
+before "/hi", &block = lambda { puts "Running before in a lambda"; puts "------------------" }
 run("/hi")
 
 run("/random")

--- a/runner.rb
+++ b/runner.rb
@@ -13,4 +13,5 @@ before "/hi" do
   puts "------------------"
 end
 
-#run("/random")  #Error
+run("/hi")
+run("/random")  #Error

--- a/runner.rb
+++ b/runner.rb
@@ -15,3 +15,13 @@ end
 run("/hi")
 
 run("/random")  #Error
+
+# Do it all again using lambdas
+
+get '/hi', &block = lambda { puts "I am in the lambda"
+run("/hi")
+
+before "/hi", &block = lambda { puts "Running before block"; puts "------------------" }
+run("/hi")
+
+run("/random")

--- a/runner.rb
+++ b/runner.rb
@@ -18,7 +18,7 @@ run("/random")  #Error
 
 # Do it all again using lambdas
 
-get '/hi', &block = lambda { puts "I am in the lambda"
+get '/hi', &block = lambda { puts "I am in the lambda" }
 run("/hi")
 
 before "/hi", &block = lambda { puts "Running before block"; puts "------------------" }

--- a/runner.rb
+++ b/runner.rb
@@ -1,17 +1,17 @@
 require "./sinatra.rb"
 
+# Procs instances get assigned to a variable, locally stored block code can be assessed later.
 get "/hi" do
-  puts "I am the hi method"
+  puts "I am in the hi block"
 end
-
-# Proc instance gets assigned to a variable, locally stored block code can be assessed later
-# run("/hi") # Error. before filter is nil
-
-before "/hi" do
-  puts "Running before filter"
-  puts "------------------"
-end
-# same here assigned to a block variable
 
 run("/hi")
+
+before "/hi" do
+  puts "Running before block"
+  puts "------------------"
+end
+
+run("/hi")
+
 run("/random")  #Error

--- a/sinatra.rb
+++ b/sinatra.rb
@@ -1,9 +1,11 @@
 module Sinatra
 
+  # for the run to message a status
   def self.included(klass)
    puts "Mock Sinatra has been included"
   end
 
+  # calling our procs
   def run(path)    
     if paths.has_key?(path)
       if before_filters.has_key?(path)
@@ -15,19 +17,23 @@ module Sinatra
     end
   end
 
+  # set up the hash or use one
   def before_filters
     @before_filters ||= {}
   end
 
+  # put the proc in a hash
   def before(path, &block)
     puts "Defining a before filter request for #{path}" 
     before_filters[path] = block
   end
 
+  # set the hash or use one
   def paths
     @paths ||= {}
   end
 
+  # put the proc in a hash
   def get(path, &block)
     puts "Defining a GET request for #{path}"    
     paths[path] = block
@@ -35,4 +41,5 @@ module Sinatra
 
 end
 
+# show that sinatra module has been run
 include Sinatra

--- a/sinatra.rb
+++ b/sinatra.rb
@@ -1,12 +1,14 @@
 module Sinatra
+
   def self.included(klass)
-   # puts "Mock Sinatra has been included"
+   puts "Mock Sinatra has been included"
   end
 
-  def run(path)
+  def run(path)    
     if paths.has_key?(path)
-      #before_filters[path.call]
-      p before_filters[path].nil?
+      if before_filters.has_key?(path)
+        before_filters[path].call
+      end      
       paths[path].call
     else
       raise StandardError.new("No route for #{path}")
@@ -18,6 +20,7 @@ module Sinatra
   end
 
   def before(path, &block)
+    puts "Defining a before filter request for #{path}" 
     before_filters[path] = block
   end
 
@@ -26,12 +29,8 @@ module Sinatra
   end
 
   def get(path, &block)
-    puts "Defining a GET request for #{path}
+    puts "Defining a GET request for #{path}"    
     paths[path] = block
-    paths.each_with_index do |(k, v), i|
-      p k, v, i
-    end
-    p paths.has_key?(path)
   end
 
 end

--- a/sinatra.rb
+++ b/sinatra.rb
@@ -54,4 +54,16 @@ and
 
 handler.run(self, server_settings) do |server|
 
+But the actual route method is this
+
+def route(verb, path, options = {}, &block)
+  # Because of self.options.host
+  host_name(options.delete(:host)) if options.key?(:host)
+  enable :empty_path_info if path == "" and empty_path_info.nil?
+  signature = compile!(verb, path, block, options)
+  (@routes[verb] ||= []) << signature
+  invoke_hook(:route_added, verb, path, block)
+  signature
+end
+
 =end

--- a/sinatra.rb
+++ b/sinatra.rb
@@ -43,3 +43,15 @@ end
 
 # show that sinatra module has been run
 include Sinatra
+
+=begin
+
+Here's how Sinatra::Base would do it
+
+routes.each do |pattern, keys, conditions, block|
+
+and
+
+handler.run(self, server_settings) do |server|
+
+=end

--- a/sinatra.rb
+++ b/sinatra.rb
@@ -66,4 +66,16 @@ def route(verb, path, options = {}, &block)
   signature
 end
 
+When I start a simple Sinatra app in irb I get something that shows we have a proc.
+[/\A\/\z/, [], [], #<Proc:0x8c62d90@/var/lib/gems/1.9.1/gems/sinatra-1.4.6/lib/sinatra/base.rb:1610>]
+
+that line is part of this ternary
+wrapper                 = block.arity != 0 ?
+          proc { |a,p| unbound_method.bind(a).call(*p) } :
+          proc { |a,p| unbound_method.bind(a).call }
+          
+Aha! A wrapper. 
+          
+
+
 =end

--- a/sinatra.rb
+++ b/sinatra.rb
@@ -25,7 +25,8 @@ module Sinatra
   end
 
   def get(path, &block)
-   # puts "Defining a GET request for #{path}"
+    puts "Defining a GET request for #{path}"
+    path = lambda { path }
     paths[path] = block
   end
 

--- a/sinatra.rb
+++ b/sinatra.rb
@@ -5,7 +5,8 @@ module Sinatra
 
   def run(path)
     if paths.has_key?(path)
-      before_filters[path.call]
+      #before_filters[path.call]
+      p before_filters[path].nil?
       paths[path].call
     else
       raise StandardError.new("No route for #{path}")
@@ -25,9 +26,12 @@ module Sinatra
   end
 
   def get(path, &block)
-    puts "Defining a GET request for #{path}"
-    path = lambda { path }
+    puts "Defining a GET request for #{path}
     paths[path] = block
+    paths.each_with_index do |(k, v), i|
+      p k, v, i
+    end
+    p paths.has_key?(path)
   end
 
 end


### PR DESCRIPTION
I figure we need something callable at least.
http://codelikethis.com/lessons/ruby_blocks/blocks.slides#proc
http://codelikethis.com/lessons/ruby_blocks/blocks.slides#making_the_default_block_visible
Many people don't really understand these things. 
see;
http://rakeroutes.com/blog/anonymous-blocks-as-function-arguments-in-ruby/
Perhaps our weeknesses will one day be our strengths. 
https://gist.github.com/DouglasAllen/2e34d1b9094ef62dc40d

After I realized that I was just stopping the key assignment, I played around with finding where the real error I was getting came from. 
My additions should show what's happening.
Inspection of the before_filters hash shows that it's nil. 
Calling the key which is a String is wrong.
So the attempt was to try the call on the before_filters hash like 

```
before_filters[path].call
```

That's when I found out that you can't call a NilClass.

In the last update we have something working.
Red, Green, Refactor.
Your turn.

One more quick link.
http://blog.carbonfive.com/2013/06/24/sinatra-best-practices-part-one/
You might like that one. I do cause he uses lambdas and just passes them in to the anon. block.
